### PR TITLE
"move kivakit-extensions/kivakit-filesystems into a separate repository"

### DIFF
--- a/telenav-superpom-kivakit/pom.xml
+++ b/telenav-superpom-kivakit/pom.xml
@@ -40,6 +40,7 @@
         <!-- KivaKit Version -->
 
         <kivakit.version>1.7.1-SNAPSHOT</kivakit.version>
+        <kivakit.filesystems.version>1.7.1</kivakit.filesystems.version>
 
     </properties>
 
@@ -105,17 +106,17 @@
             <dependency>
                 <groupId>com.telenav.kivakit</groupId>
                 <artifactId>kivakit-filesystems-hdfs</artifactId>
-                <version>${kivakit.version}</version>
+                <version>${kivakit.filesystems.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.telenav.kivakit</groupId>
                 <artifactId>kivakit-filesystems-hdfs-proxy-spi</artifactId>
-                <version>${kivakit.version}</version>
+                <version>${kivakit.filesystems.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.telenav.kivakit</groupId>
                 <artifactId>kivakit-filesystems-s3fs</artifactId>
-                <version>${kivakit.version}</version>
+                <version>${kivakit.filesystems.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.telenav.kivakit</groupId>

--- a/telenav-superpom-kivakit/pom.xml
+++ b/telenav-superpom-kivakit/pom.xml
@@ -9,9 +9,9 @@
 -->
 
 <project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+        xmlns = "http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation = "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -40,7 +40,6 @@
         <!-- KivaKit Version -->
 
         <kivakit.version>1.7.1-SNAPSHOT</kivakit.version>
-        <kivakit.filesystems.version>1.7.1</kivakit.filesystems.version>
 
     </properties>
 
@@ -106,17 +105,17 @@
             <dependency>
                 <groupId>com.telenav.kivakit</groupId>
                 <artifactId>kivakit-filesystems-hdfs</artifactId>
-                <version>${kivakit.filesystems.version}</version>
+                <version>1.7.1</version>
             </dependency>
             <dependency>
                 <groupId>com.telenav.kivakit</groupId>
                 <artifactId>kivakit-filesystems-hdfs-proxy-spi</artifactId>
-                <version>${kivakit.filesystems.version}</version>
+                <version>1.7.1</version>
             </dependency>
             <dependency>
                 <groupId>com.telenav.kivakit</groupId>
                 <artifactId>kivakit-filesystems-s3fs</artifactId>
-                <version>${kivakit.filesystems.version}</version>
+                <version>1.7.1</version>
             </dependency>
             <dependency>
                 <groupId>com.telenav.kivakit</groupId>


### PR DESCRIPTION
"move kivakit-extensions/kivakit-filesystems into a separate repository

move kivakit filesystems into a separate repository and remove them from the build after publishing to maven central


Related Pull Requests
---------------------

  * https://github.com/Telenav/kivakit-extensions/pull/46
  * https://github.com/Telenav/kivakit-stuff/pull/16


Creating Pull Requests In
-------------------------

  * cactus feature/relocate-filesystems -> develop
  * kivakit feature/relocate-filesystems -> develop
  * kivakit-examples feature/relocate-filesystems -> develop
  * kivakit-extensions feature/relocate-filesystems -> develop
  * kivakit-filesystems feature/relocate-filesystems -> develop
  * kivakit-stuff feature/relocate-filesystems -> develop
  * lexakai feature/relocate-filesystems -> develop
  * lexakai-annotations feature/relocate-filesystems -> develop
  * mesakit feature/relocate-filesystems -> develop
  * mesakit-examples feature/relocate-filesystems -> develop
  * mesakit-extensions feature/relocate-filesystems -> develop
  * safety-service feature/relocate-filesystems -> develop
  * telenav-superpom feature/relocate-filesystems -> develop
  * safety-service-build feature/relocate-filesystems -> develop


Metadata
--------

  * Invoked on com.telenav.scout.safetyservice:safety-service-uber-bom:1.1.1-SNAPSHOT
  * SearchNonce: YRDGB9cfPJ-rimvl7

##### Provenance

Generated by cactus: *cactus-git* version _1.5.31_.

  * Mojo:		GitHubPullCreateRequestMojo
  * Generation-Time:	2022-09-22T22:54:17Z
  * Plugin-Build:	yellow rabbit
  * Plugin-Date:	2022.09.10
  * Plugin-Commit:	f32552996bf3511e8901928b6467df125bdebbd2
  * Plugin-Repo-Clean:	true
"